### PR TITLE
Change location recordings to match that of other modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 import setuptools
 
 setuptools.setup(name="wwdtm",
-                 version="1.2.0.1",
+                 version="1.2.1",
                  description="Wait Wait... Don't Tell Me! Data Access Library",
                  long_description=("Provides show, host, scorekeeper, panelist and guest details "
                                    "from an instance of the Wait Wait... Don't Tell Me! Stats Page "

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -95,6 +95,8 @@ def test_retrieve_recordings_by_id(location_id: int,
                                                       database_connection)
     assert location_dict is not None
     assert "recordings" in location_dict
+    assert "count" in location_dict["recordings"]
+    assert "shows" in location_dict["recordings"]
     if print_response:
         print(json.dumps(location_dict, indent=2))
 
@@ -106,6 +108,8 @@ def test_retrieve_recordings_by_slug(location_slug: str,
                                                         database_connection)
     assert location_dict is not None
     assert "recordings" in location_dict
+    assert "count" in location_dict["recordings"]
+    assert "shows" in location_dict["recordings"]
     if print_response:
         print(json.dumps(location_dict, indent=2))
 

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -5,4 +5,4 @@
 
 from wwdtm import guest, host, location, panelist, scorekeeper, show
 
-VERSION = "1.2.0.1"
+VERSION = "1.2.1"


### PR DESCRIPTION
With the addition of locations section and location details being added to the Stats Page, needed to change location["recordings"] to from a list to a dictionary containing both counts and list of shows.