### PR TITLE
Change location order when ordering by venue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 import setuptools
 
 setuptools.setup(name="wwdtm",
-                 version="1.2.1.1",
+                 version="1.2.1.2",
                  description="Wait Wait... Don't Tell Me! Data Access Library",
                  long_description=("Provides show, host, scorekeeper, panelist and guest details "
                                    "from an instance of the Wait Wait... Don't Tell Me! Stats Page "

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -5,4 +5,4 @@
 
 from wwdtm import guest, host, location, panelist, scorekeeper, show
 
-VERSION = "1.2.1.1"
+VERSION = "1.2.1.2"

--- a/wwdtm/location/info.py
+++ b/wwdtm/location/info.py
@@ -29,7 +29,7 @@ def retrieve_all(database_connection: mysql.connector.connect,
                  "WHERE locationid NOT IN (3) ")
 
         if sort_by_venue:
-            query = query + "ORDER BY venue ASC, state ASC, city ASC;"
+            query = query + "ORDER BY venue ASC, city ASC, state ASC;"
         else:
             query = query + "ORDER BY state ASC, city ASC, venue ASC;"
 
@@ -69,7 +69,7 @@ def retrieve_all_ids(database_connection: mysql.connector.connect,
                  "WHERE locationid NOT IN (3) ")
 
         if sort_by_venue:
-            query = query + "ORDER BY venue ASC, state ASC, city ASC;"
+            query = query + "ORDER BY venue ASC, city ASC, state ASC;"
         else:
             query = query + "ORDER BY state ASC, city ASC, venue ASC;"
 


### PR DESCRIPTION
Fix the sort order when getting recording locations and sorting by venue. Now sorts by venue, then city, then state.